### PR TITLE
<feat>: Frame Entitiy 추가

### DIFF
--- a/src/main/java/com/example/Mad4Cut/controller/AuthController.java
+++ b/src/main/java/com/example/Mad4Cut/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/member")
 
 @Slf4j
 public class AuthController {
@@ -31,7 +31,7 @@ public class AuthController {
     private MemberService memberService;
 
 
-    @PostMapping("/naver")
+    @PostMapping("/login")
     public ApiResponse<ApiResponse.SuccessBody<AccessNaverInfo>> authenticateWithNaver(@RequestBody NaverTokenRequest request) {
         String naverProfile = naverService.getNaverProfile(request.getToken());
         // 네이버 프로필 정보 기반으로 사용자 저장 또는 업데이트

--- a/src/main/java/com/example/Mad4Cut/controller/FrameController.java
+++ b/src/main/java/com/example/Mad4Cut/controller/FrameController.java
@@ -1,0 +1,56 @@
+package com.example.Mad4Cut.controller;
+
+import com.example.Mad4Cut.domain.Frame;
+import com.example.Mad4Cut.domain.Image;
+import com.example.Mad4Cut.domain.dto.response.FrameListInfo;
+import com.example.Mad4Cut.domain.dto.response.ImageListInfo;
+import com.example.Mad4Cut.security.JwtTokenProvider;
+import com.example.Mad4Cut.service.FrameService;
+import com.example.Mad4Cut.service.ImageService;
+import com.example.Mad4Cut.support.ApiResponse;
+import com.example.Mad4Cut.support.ApiResponseGenerator;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+
+@Controller
+@RequestMapping("/api/v1")
+public class FrameController {
+
+    private FrameService frameService;
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public FrameController(FrameService frameService, JwtTokenProvider jwtTokenProvider) {
+        this.frameService = frameService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+    @GetMapping("/frames")
+    public ApiResponse<ApiResponse.SuccessBody<FrameListInfo>> getImage(HttpServletRequest request){
+        Long memberId = findMemberByToken(request);
+        List<Frame> frames = frameService.getAllFrames();
+
+        FrameListInfo res = FrameListInfo.builder()
+                .frames(frames)
+                .build();
+        return ApiResponseGenerator.success(res, HttpStatus.CREATED);
+    }
+
+
+    private Long findMemberByToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            return jwtTokenProvider.getUserIdFromToken(token);
+        } else {
+            throw new IllegalArgumentException("Invalid or missing Authorization header");
+        }
+    }
+}

--- a/src/main/java/com/example/Mad4Cut/controller/ImageController.java
+++ b/src/main/java/com/example/Mad4Cut/controller/ImageController.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 
 @RestController
-@RequestMapping("/images")
+@RequestMapping("/api/v1/member")
 public class ImageController {
 
     private final ImageService imageService;
@@ -30,7 +30,7 @@ public class ImageController {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    @PostMapping("/upload")
+    @PostMapping("/gallery/save")
     public ApiResponse<ApiResponse.SuccessBody<ImageInfo>> uploadImage(@RequestPart("file") MultipartFile file, HttpServletRequest request) throws IOException {
         Long memberId = findMemberByToken(request);
         String fileUrl = imageService.saveImage(file, memberId);
@@ -43,7 +43,7 @@ public class ImageController {
         return ApiResponseGenerator.success(res, HttpStatus.CREATED);
     }
 
-    @GetMapping("/getimage")
+    @GetMapping("/gallery")
     public ApiResponse<ApiResponse.SuccessBody<ImageListInfo>> getImage(HttpServletRequest request){
         Long memberId = findMemberByToken(request);
         List<Image> images = imageService.getImagesByMemberId(memberId);

--- a/src/main/java/com/example/Mad4Cut/domain/Frame.java
+++ b/src/main/java/com/example/Mad4Cut/domain/Frame.java
@@ -1,0 +1,24 @@
+package com.example.Mad4Cut.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Frame {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="frameId")
+    private Long id;
+
+    @Column(name = "url")
+    private String url;
+
+    @Builder
+    public Frame(String url) {
+        this.url = url;
+    }
+
+}

--- a/src/main/java/com/example/Mad4Cut/domain/dto/response/FrameListInfo.java
+++ b/src/main/java/com/example/Mad4Cut/domain/dto/response/FrameListInfo.java
@@ -1,0 +1,16 @@
+package com.example.Mad4Cut.domain.dto.response;
+
+import com.example.Mad4Cut.domain.Frame;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class FrameListInfo {
+    private List<Frame> frames;
+}

--- a/src/main/java/com/example/Mad4Cut/repository/FrameRepository.java
+++ b/src/main/java/com/example/Mad4Cut/repository/FrameRepository.java
@@ -1,0 +1,12 @@
+package com.example.Mad4Cut.repository;
+
+import com.example.Mad4Cut.domain.Frame;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FrameRepository extends JpaRepository<Frame, Long> {
+    List<Frame> findAll();
+}

--- a/src/main/java/com/example/Mad4Cut/security/SecurityConfig.java
+++ b/src/main/java/com/example/Mad4Cut/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/", "/home", "/login", "/oauth2/**", "/auth/*", "/test", "/images/**").permitAll()
+                                .requestMatchers("/api/v1/member/login", "/api/v1/member/generate-token", "/test" , "/images/**", "/frames/**").permitAll()
                                 .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/Mad4Cut/service/FrameService.java
+++ b/src/main/java/com/example/Mad4Cut/service/FrameService.java
@@ -1,0 +1,28 @@
+package com.example.Mad4Cut.service;
+
+import com.example.Mad4Cut.domain.Frame;
+import com.example.Mad4Cut.domain.Image;
+import com.example.Mad4Cut.repository.FrameRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+public class FrameService {
+
+
+    @Autowired
+    private final FrameRepository frameRepository;
+
+    public FrameService(FrameRepository frameRepository) {
+        this.frameRepository = frameRepository;
+    }
+
+    public List<Frame> getAllFrames() {
+        return frameRepository.findAll();
+    }
+
+
+}


### PR DESCRIPTION
4컷의 프레임 불러오기 기능 추가 및 전체 api PATH 명세에 맞게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 새로운 `FrameController` 추가: 프레임 관련 API 요청 처리.
  - `Frame` 엔티티 클래스 추가: 프레임 데이터 관리.
  - `FrameListInfo` DTO 클래스 추가: 프레임 목록 정보 전달.
  - `FrameRepository` 인터페이스 추가: 프레임 데이터베이스 접근.
  - `FrameService` 클래스 추가: 프레임 데이터 처리 로직 구현.
  
- **변경 사항**
  - 인증 경로 업데이트: `/auth` → `/api/v1/member`.
  - 로그인 엔드포인트 경로 변경: `/naver` → `/login`.
  - 이미지 엔드포인트 경로 변경: `/images/upload` → `/api/v1/member/gallery/save`, `/images/getimage` → `/api/v1/member/gallery`.
  - 보안 설정 업데이트: 새로운 엔드포인트에 대한 접근 권한 설정 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->